### PR TITLE
Change metachain to zetachain in import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kurtosis packages can be composed inside other Kurtosis packages. To use this pa
 First, import this package by adding the following to the top of your Starlark file:
 
 ```python
-this_package = import_module("github.com/CryptoFewka/metachain-package/main.star")
+this_package = import_module("github.com/CryptoFewka/zetachain-package/main.star")
 ```
 
 Then, call the this package's `run` function somewhere in your Starlark script:


### PR DESCRIPTION
Hey @CryptoFewka  , just noticed this small typo in the README, in the import statement for using this package in other packages. Thought I'd submit a quick fix!